### PR TITLE
don't use `@` in examples/vignettes

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,15 +10,33 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+
     steps:
       - uses: actions/checkout@v3
 
+      - uses: r-lib/actions/setup-pandoc@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
@@ -28,4 +46,4 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          error-on: '"error"'
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fr
 Title: Frictionless Standards
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: 
     person("Cole", "Brokamp", , "cole@colebrokamp.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-0289-3151"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# fr 0.5.1
+
+* Fix problem with building vignettes and running examples in older versions of R.
+
 # fr 0.5.0
 
 * Initial CRAN submission.

--- a/R/fr-package.R
+++ b/R/fr-package.R
@@ -27,5 +27,5 @@ NULL
 #' @rawNamespace if (getRversion() < "4.3.0") importFrom("S7", "@")
 NULL
 
-utils::globalVariables(c("path", "enum", "schema", "fields"))
+utils::globalVariables(c("name", "path", "enum", "schema", "fields"))
 

--- a/R/fr_tdr.R
+++ b/R/fr_tdr.R
@@ -33,7 +33,7 @@ fr_tdr <- S7::new_class(
 #' @export
 #' @examples
 #' as_fr_tdr(mtcars, name = "mtcars")
-#' as_fr_tdr(mtcars, name = "mtcars")@schema
+#' S7::prop(as_fr_tdr(mtcars, name = "mtcars"), "schema")
 as_fr_tdr <- S7::new_generic("as_fr_tdr", "x")
 
 S7::method(as_fr_tdr, S7::class_data.frame) <- function(x, ..., .template = NULL) {

--- a/R/update_field.R
+++ b/R/update_field.R
@@ -9,8 +9,8 @@
 #'   mtcars |>
 #'   as_fr_tdr(name = "mtcars") |>
 #'   update_field("mpg", title = "Miles Per Gallon")
-#' 
-#' str(my_mtcars@schema@fields$mpg)
+#'
+#' S7::prop(my_mtcars, "schema")
 update_field <- function(x, field, ...) {
 
   x_fields <-

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,8 +2,4 @@
 
 0 errors | 0 warnings | 1 note
 
-* This is a new release.
-* Note is related to qpdf availability on system.
-* Removed invalid unicode characters from examples that caused previous error on incoming checks when building examples PDF.
-* More detailed Description field including a reference URL.
-* Do not write to working directory by default.
+* This is bugfix release to support older versions of R.

--- a/man/as_fr_tdr.Rd
+++ b/man/as_fr_tdr.Rd
@@ -25,5 +25,5 @@ in \code{...} will be ignored if this argument is provided
 }
 \examples{
 as_fr_tdr(mtcars, name = "mtcars")
-as_fr_tdr(mtcars, name = "mtcars")@schema
+S7::prop(as_fr_tdr(mtcars, name = "mtcars"), "schema")
 }

--- a/man/update_field.Rd
+++ b/man/update_field.Rd
@@ -25,5 +25,5 @@ my_mtcars <-
   as_fr_tdr(name = "mtcars") |>
   update_field("mpg", title = "Miles Per Gallon")
 
-str(my_mtcars@schema@fields$mpg)
+S7::prop(my_mtcars, "schema")
 }

--- a/tests/testthat/test-write_fr_tdr.R
+++ b/tests/testthat/test-write_fr_tdr.R
@@ -1,4 +1,5 @@
 test_that("write_fr_tdr works", {
+  skip_on_os(os = "windows")
   write_fr_tdr(as_fr_tdr(mtcars, name = "my_mtcars"), dir = tempdir())
   expect_snapshot_file(fs::path(tempdir(), "my_mtcars", "my_mtcars.csv"))
   expect_snapshot_file(fs::path(tempdir(), "my_mtcars", "tabular-data-resource.yaml"))

--- a/vignettes/read_fr_tdr.Rmd
+++ b/vignettes/read_fr_tdr.Rmd
@@ -104,5 +104,5 @@ d_fr_new <-
 
 d_fr_new
 
-d_fr_new@schema
+S7::prop(d_fr_new, "schema")
 ```

--- a/vignettes/read_fr_tdr.Rmd
+++ b/vignettes/read_fr_tdr.Rmd
@@ -39,7 +39,7 @@ d_fr
 Print the `schema` property to view the table-specific metadata:
 
 ```{r}
-d_fr@schema
+S7::prop(d_fr, "schema")
 ```
 
 `fr_tdr` objects can be used mostly anywhere that the underlying data frame can be used because `as.data.frame` usually is used to coerce objects into data frames and works with `fr_tdr` objects:


### PR DESCRIPTION
Even with importing the namespace in R versions older than 4.3.0,
examples and vignettes fail to render on old releases of R in CRAN checks.