### PR TITLE
Update for S7 v0.2.0; Set `package = NULL` in `new_class()`

### DIFF
--- a/R/fr_field.R
+++ b/R/fr_field.R
@@ -75,7 +75,7 @@ S7::method(as_fr_field, S7::class_Date) <- function(x, name, ...) {
 #' is_fr_field(as_fr_field(letters, "letters"))
 #' @export
 is_fr_field <- function(x) {
-  inherits(x, "fr_field")
+  S7::S7_inherits(x, fr_field)
 }
 
 

--- a/R/fr_field.R
+++ b/R/fr_field.R
@@ -1,5 +1,6 @@
 fr_field <- S7::new_class(
   "fr_field",
+  package = NULL,
   properties = list(
     name = S7::class_character,
     type = S7::class_character,

--- a/R/fr_schema.R
+++ b/R/fr_schema.R
@@ -1,5 +1,6 @@
 ## https://specs.frictionlessdata.io/table-schema
 fr_schema <- S7::new_class(
+  package = NULL,
   "fr_schema",
   properties = list(
     fields = S7::class_list,

--- a/R/fr_tdr.R
+++ b/R/fr_tdr.R
@@ -1,4 +1,5 @@
 fr_tdr <- S7::new_class(
+  package = NULL,
   "fr_tdr",
   parent = S7::class_data.frame,
   properties = list(
@@ -62,7 +63,7 @@ S7::method(as_fr_tdr, S7::class_data.frame) <- function(x, ..., .template = NULL
         .init = d_tdr)
     S7::props(out) <- S7::props(.template)[c("name", "version", "title", "homepage", "description")]
   }
-  
+
   return(out)
 }
 


### PR DESCRIPTION
Starting with S7 0.2.0, `S7::new_class()` automatically infers the package name, which changes the S3 class of S7 objects defined in a package and causes tests like `expect_s3_class(fr_field(), "fr_field")` to fail. By default, the S3 class name now includes the package name.

This patch preserves the current S3 class name for S7 classes defined by the package. Alternatively, you could update the tests to use the new S3 class, e.g., 
```
expect_s3_class(fr_field(), "fr::fr_field")
```

or,
```
expect_s3_class(fr_field(), nameOfClass(fr_field))
```